### PR TITLE
Unit tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'active_support'
+require 'active_support/all'
 require 'strapi'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'active_support'
 require 'strapi'

--- a/spec/strapi_spec.rb
+++ b/spec/strapi_spec.rb
@@ -1,11 +1,4 @@
 require 'spec_helper'
 
 describe Strapi do
-  it 'has a version number' do
-    expect(Strapi::VERSION).not_to be nil
-  end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/unit/controller_methods_spec.rb
+++ b/spec/unit/controller_methods_spec.rb
@@ -1,0 +1,105 @@
+require 'active_support/inflector'
+
+# define classes retrieved by constant name
+class WidgetQuery
+  def initialize(*)
+  end
+end
+
+class WidgetFilter
+end
+
+describe Strapi::ControllerMethods do
+  let(:controller) {
+    Class.new do
+      include Strapi::ControllerMethods
+    end
+  }
+  subject(:controller_instance) { controller.new }
+
+  describe '#index' do
+    let(:record_factory) { double('Widget', to_s: 'Widget', all: relation) }
+    let(:relation) { instance_double('relation') }
+    let(:filter_params) { double('filter_params') }
+    let(:filter_instance) { double('filter_instance', scope: relation) }
+
+    after do
+      # define methods required on controller instance
+      allow(controller_instance).to receive(:params).and_return({
+        filter: filter_params
+      })
+      allow(controller_instance).to receive(:record_factory).and_return(record_factory)
+      allow(controller_instance).to receive(:allowed_sort_keys)
+      allow(controller_instance).to receive(:policy_scope).and_return(relation)
+      allow(controller_instance).to receive(:serializer_includes).and_return(['included'])
+      allow(controller_instance).to receive(:respond_with)
+
+      # define methods used on relation:
+      # ActiveRecord::Relation chainable methods
+      %i(order page per includes).each do |method|
+        allow(relation).to receive(method).and_return(relation)
+      end
+      # ActiveRecord::Relation pagination methods
+      %i(current_page next_page prev_page total_pages total_count).each do |method|
+        allow(relation).to receive(method).and_return(method)
+      end
+
+      # define methods required on filter
+      allow(WidgetFilter).to receive(:new).and_return(filter_instance)
+
+      # actually call the index method
+      controller_instance.index
+    end
+
+    it "depends on a `record_factory` method in the controller to retrieve the model class" do
+      expect(controller_instance).to receive(:record_factory)
+    end
+
+    it "retrieves all records from the record factory" do
+      expect(record_factory).to receive(:all)
+    end
+
+    it "retrieves a query corresponding to the model" do
+      # but doesn't use it--should it be responsible for passing it along to the filter?
+      expect(WidgetQuery).to receive(:new).with(filter_params)
+    end
+
+    it "retrieves a filter corresponding to the model" do
+      expect(WidgetFilter).to receive(:new).with({
+        query: WidgetQuery,
+        initial_scope: relation
+      })
+    end
+
+    it "depends on an `allowed_sort_keys` method in the controller" do
+      expect(controller_instance).to receive(:allowed_sort_keys)
+    end
+
+    # mock the sort class?
+
+    it "uses the policy scope" do
+      expect(controller_instance).to receive(:policy_scope).with(relation)
+    end
+
+    it "depends on a `serializer_includes` method in the controller" do
+      expect(controller_instance).to receive(:serializer_includes)
+    end
+
+    it "responds with the relation and pagination metadata" do
+      expect(controller_instance).to receive(:respond_with).with(relation,
+        {
+          include: ['included'],
+          meta: {
+            pagination: {
+              current_page: :current_page,
+              next_page: :next_page,
+              prev_page: :prev_page,
+              total_pages: :total_pages,
+              total_count: :total_count,
+            }
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/unit/controller_methods_spec.rb
+++ b/spec/unit/controller_methods_spec.rb
@@ -1,5 +1,3 @@
-require 'active_support/inflector'
-
 # define classes retrieved by constant name
 class WidgetQuery
   def initialize(*)

--- a/strapi.gemspec
+++ b/strapi.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 4.0"
+  spec.add_dependency "activesupport", "~> 5.0"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Would love some input on this first shot at unit-testing. Partial-stubbing is of course complex, but I think it’s unavoidable to test a module that’s included into another module.
- Is there a better or more narrowly-scoped way to hook up with active support?
- Having to list all the “allows” to set up the controller instance and then “expect” them later is verbose, but the “allows” are needed so each example can call all those methods. Does it make sense to combine it all into one big example so those can just be expectations set once?
- Or does it make sense to actually define those methods on the `:controller` class? But if I do that, I was having trouble accessing `let` variables from within that class to return stuff. Should I be able to do that?

I’m sure there are lots of other things that could be improved.

Incidentally, I didn’t use one-line syntax for the expectations because I wanted to write out in more verbose english _what_ I was specifying, so that it made sense to me that I actually want to specify it, not just allow it.
